### PR TITLE
Fixes for deprecations

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -47,6 +47,10 @@ import Zlib
 
 export read, eof, write, close, mtime, position, show
 
+if !isdefined(:read!)
+    read! = read
+end
+
 # TODO: ZIP64 support, data descriptor support
 
 const _LocalFileHdrSig   = 0x04034b50
@@ -406,7 +410,7 @@ function read{T}(f::ReadableFile, a::Array{T})
 	
 	seek(f._io, f._datapos+f._zpos)
 	b = reinterpret(Uint8, reshape(a, length(a)))
-	read(f._zio, b)
+	read!(f._zio, b)
 	f._zpos = position(f._io) - f._datapos
 	f._pos += length(b)
 	f._currentcrc32 = Zlib.crc32(b, f._currentcrc32)

--- a/src/iojunk.jl
+++ b/src/iojunk.jl
@@ -20,7 +20,7 @@ function write{T,N,A<:Array}(w::WritableFile, a::SubArray{T,N,A})
 		return write(w, pointer(a, 1), colsz)
 	else
 		cartesianmap((idxs...)->write(w, pointer(a, idxs), colsz),
-			tuple(1, size(a)[2:]...))
+			tuple(1, size(a)[2:end]...))
 		return colsz*Base.trailingsize(a,2)
 	end
 end


### PR DESCRIPTION
Because of the `ifdefined` block, this should work on modern and older versions of Julia.
