### PR TITLE
Handle IOBuffer better in ZipFile.Writer

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -352,7 +352,9 @@ function close(w::Writer)
 	_writele(w._io, @compat UInt32(cdpos))
 	_writele(w._io, @compat UInt16(0))
 
-	close(w._io)
+	if !isa(w._io, IOBuffer)
+		close(w._io)
+	end
 end
 
 # Flush the file f into the ZIP file.


### PR DESCRIPTION
In `close(f::WritableFile)`, don't close the underlying `io` if it is an `IOBuffer` (otherwise the data is lost!).

e.g...

```julia
# Convert dictionarty to .ZIP data...

function zipdict(d::Dict{AbstractString,Any})

    io = IOBuffer()

    w = ZipFile.Writer(io);
    for (k,v) in d
        f = ZipFile.addfile(w, k, method=ZipFile.Deflate)
        write(f, v)
        close(f)
    end
    close(w)

    zip = takebuf_array(io)
    close(io)

    return zip
end
```