### PR TITLE
Fix the print zipfile content example

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,7 +33,7 @@ Read and print out the contents of a ZIP file::
 	r = ZipFile.Reader("example.zip");
 	for f in r.files
 		println("Filename: $(f.name)")
-		write(readstring(f));
+		write(STDOUT, readstring(f));
 	end
 	close(r)
 


### PR DESCRIPTION
I'm new to Julia, so not sure when the example stopped working but (at least on my installation of Version 0.5.0 (2016-09-19 18:14 UTC)) I had to alter the write command in the example.