### PR TITLE
Add flush(::Writer) to write central directory record without closing file

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -398,6 +398,9 @@ function flush(w::Writer)
     _writele(w._io, UInt16(0))
 
     flush(w._io)
+
+    # Seek to the beginning of central directory so that appending
+    # more files will overwrite it.
     seek(w._io, cdpos)
 
     return
@@ -421,6 +424,13 @@ function close(f::WritableFile)
     _writele(f._io, UInt32(f.crc32))
     _writele(f._io, UInt32(f.compressedsize))
     _writele(f._io, UInt32(f.uncompressedsize))
+
+    # Seek to the end of file `f`.  Note that we can't use
+    # `seekend(f._io)` because the end position of the physical zip
+    # file can be larger than the position `pos` of the end of the
+    # file `f` if `flush(::Writer)` has been called before and the
+    # size of this file `f` is smaller than the central directory
+    # record.
     seek(f._io, pos)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,23 @@ for x in data
 end
 close(dir)
 
+filename = "$tmp/flush.zip"
+dir = ZipFile.Writer(filename)
+f = ZipFile.addfile(dir, "1")
+write(f, "data-1")
+flush(dir)
+r = ZipFile.Reader(filename)
+@test read(r.files[1], String) == "data-1"
+close(r)
+f = ZipFile.addfile(dir, "2")
+write(f, "data-2")
+flush(dir)
+r = ZipFile.Reader(filename)
+@test read(r.files[1], String) == "data-1"
+@test read(r.files[2], String) == "data-2"
+close(r)
+close(dir)
+
 
 if !Debug
     rm(tmp, recursive=true)


### PR DESCRIPTION
This PR implements `flush(::Writer)` to write out central directory record without closing the file. It is useful for, e.g., appending to a zip file in a long-running Julia process while keeping the zip file valid and readable by external programs.