### PR TITLE
implement unsafe_read for for ReadableFile

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -491,7 +491,7 @@ function read(f::ReadableFile, ::Type{UInt8})
     byte
 end
 
-function unsafe_read(f::ReadableFile, p::Ptr{UInt8}, n::UInt)
+function Base.unsafe_read(f::ReadableFile, p::Ptr{UInt8}, n::UInt)
     ensure_zio!(f)
     seek(f._io, f._datapos+f._zpos)
     b = unsafe_wrap(Array{UInt8, 1}, p, n)

--- a/src/iojunk.jl
+++ b/src/iojunk.jl
@@ -2,12 +2,3 @@
 function write(w::WritableFile, b::UInt8)
     write(w, Ref(b))
 end
-
-# Read and return a byte from f. Throws EOFError if there is no more byte to read.
-function read(f::ReadableFile, ::Type{UInt8})
-    # This function needs to be fast because readbytes, readstring, etc.
-    # uses it. Avoid function calls when possible.
-    b = Vector{UInt8}(undef, 1)
-    c = read(f, b)
-    c[1]
-end


### PR DESCRIPTION
This also has some light refactoring to pull out the common steps out of `_read`

ref https://github.com/felipenoris/XLSX.jl/issues/135

I get about a 6x speedup on a modest sized Excel file
```
# PR
julia> @btime XLSX.readtable(f, "Sheet1")
  129.633 ms (417325 allocations: 17.26 MiB)

# master
julia> @btime XLSX.readtable(f, "Sheet1")
  767.820 ms (4570005 allocations: 184.98 MiB)
```