### PR TITLE
Added custom read(::ReadableFile)

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -500,6 +500,18 @@ function Base.unsafe_read(f::ReadableFile, p::Ptr{UInt8}, n::UInt)
     nothing
 end
 
+function read(f::ReadableFile, nb::Integer=typemax(Int))
+    ensure_zio!(f)
+
+    nb = min(nb, f.uncompressedsize - f._pos)
+    b = Vector{UInt8}(undef, nb)
+    seek(f._io, f._datapos+f._zpos)
+    read!(f._zio, b)
+    update_reader!(f, b)
+
+    return b
+end
+
 function _read(f::ReadableFile, a::Array{T}) where T
     ensure_zio!(f)
 


### PR DESCRIPTION
Based on the implementation in `io.jl`. Should help with #69.

As far as I can tell, this implementation is identical to `read!(::ReadableFile, ::Array{UInt8})` used in @Arkoniak's workaround in https://github.com/fhs/ZipFile.jl/issues/69#issuecomment-660623164. It is significantly faster according to my timings and I get the same performance improvement on their dataset as they claim in the comment. I did not manage to cleanly implement `readbytes!`, so I left it out for now.