### PR TITLE
Add `GC.@preserve` where `pointer()` is used

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -521,8 +521,10 @@ function _read(f::ReadableFile, a::Array{T}) where T
 
     seek(f._io, f._datapos+f._zpos)
     b = unsafe_wrap(Array{UInt8, 1}, reinterpret(Ptr{UInt8}, pointer(a)), sizeof(a))
-    read!(f._zio, b)
-    update_reader!(f, b)
+    GC.@preserve a begin
+        read!(f._zio, b)
+        update_reader!(f, b)
+    end
 
     return a
 end


### PR DESCRIPTION
This should fix #71

Using the value returned by `pointer()` is unsafe unless Julia is told
to preserve the owner of that memory. `GC.@preserve` is the right way to
do this.  In some cases the `GC.@preserve` used here may cover a
slightly larger scope than may be strictly necessary. But this should be ok,
as it's essentially free.

Also set the pointer fields `next_in` and `next_out` to `C_NULL`
whenever we're finished with them to prevent use-after-free surprises.
While not exactly necessary in an ideal bug-free world, this should help
with robustness by detecting any accidental reuse of stale buffers.
