### PR TITLE
Add `seek(::ReadableFile, 0)` and `readavailable()`

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -594,6 +594,20 @@ function position(f::ReadableFile)
     f._pos
 end
 
+function Base.seek(io::ReadableFile, n::Integer)
+    # It's not possible to seek the compressed stream without an extra
+    # compression index, so only support seeking to the start.
+    n == 0 || throw(ArgumentError("Cannot efficiently seek zip stream to nonzero offset $n"))
+    io._datapos = -1
+    io._currentcrc32 = 0
+    io._pos = 0
+    io._zpos = 0
+    return io
+end
+
+# Needed for use as `src` in `write(dst::IO, src::IO)`.
+Base.readavailable(io::ZipFile.ReadableFile) = read(io)
+
 # Write nb elements located at p into f.
 function unsafe_write(f::WritableFile, p::Ptr{UInt8}, nb::UInt)
     # zlib doesn't like 0 length writes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,11 @@ dir = ZipFile.Reader(filename)
 @test String(read!(dir.files[1], Array{UInt8}(undef, length(s1)))) == s1
 @test String(read!(dir.files[1], Array{UInt8}(undef, length(s2)))) == s2
 @test eof(dir.files[1])
+@test_throws ArgumentError seek(dir.files[1], 1)
+# Can seek back to start
+seek(dir.files[1], 0)
+# Test readavailable()
+@test String(readavailable(dir.files[1])) == s1*s2
 close(dir)
 
 


### PR DESCRIPTION
It's sometimes useful to be able to seek back to the start of a file inside a zip. I've disabled seeking elsewhere, as it can't be done efficiently in general (at least, not without an extra index which the zip format doesn't include).

I also needed `readavailable()` for using a `ReadableFile` as `src` in `write(dst::IO, src::IO)`.