### PR TITLE
Fix handling of UTF-8 filenames

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -35,7 +35,7 @@ Julia
 """
 module ZipFile
 
-import Base: read, read!, eof, write, flush, close, mtime, position, show, unsafe_write
+import Base: read, read!, eof, write, flush, close, mtime, position, show, unsafe_write, Sys
 using Printf
 
 export read, read!, eof, write, close, mtime, position, show
@@ -60,6 +60,12 @@ const _Method2Str = Dict{UInt16,String}(Store => "Store", Deflate => "Deflate")
 
 "Unicode filename flag"
 const _UnicodeFlag = 0x800
+
+"Version made by"
+const _VersionMadeBy = (Sys.iswindows() ? 0x0a00 : 0x0300) | _ZipVersion
+
+"Default external file attributes: -rw-r-----"
+const _DefaultExtFileAttr = Sys.iswindows() ? 0 : (UInt32(0o640) << 16)
 
 mutable struct ReadableFile <: IO
     _io :: IO
@@ -369,7 +375,7 @@ function flush(w::Writer)
     # write central directory record
     for f in w.files
         _writele(w._io, UInt32(_CentralDirSig))
-        _writele(w._io, UInt16(_ZipVersion))
+        _writele(w._io, UInt16(_VersionMadeBy))
         _writele(w._io, UInt16(_ZipVersion))
         _writele(w._io, UInt16(_UnicodeFlag))
         _writele(w._io, UInt16(f.method))
@@ -384,7 +390,7 @@ function flush(w::Writer)
         _writele(w._io, UInt16(0))
         _writele(w._io, UInt16(0))
         _writele(w._io, UInt16(0))
-        _writele(w._io, UInt32(0))
+        _writele(w._io, UInt32(_DefaultExtFileAttr))
         _writele(w._io, UInt32(f._offset))
         _writele(w._io, b)
         cdsize += 46+length(b)

--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -58,6 +58,9 @@ const Deflate = UInt16(8)
 
 const _Method2Str = Dict{UInt16,String}(Store => "Store", Deflate => "Deflate")
 
+"Unicode filename flag"
+const _UnicodeFlag = 0x800
+
 mutable struct ReadableFile <: IO
     _io :: IO
     name :: String   # filename
@@ -368,7 +371,7 @@ function flush(w::Writer)
         _writele(w._io, UInt32(_CentralDirSig))
         _writele(w._io, UInt16(_ZipVersion))
         _writele(w._io, UInt16(_ZipVersion))
-        _writele(w._io, UInt16(0))
+        _writele(w._io, UInt16(_UnicodeFlag))
         _writele(w._io, UInt16(f.method))
         _writele(w._io, UInt16(f.dostime))
         _writele(w._io, UInt16(f.dosdate))
@@ -563,7 +566,7 @@ function addfile(w::Writer, name::AbstractString; method::Integer=Store, mtime::
     # Write local file header. Missing entries will be filled in later.
     _writele(w._io, UInt32(_LocalFileHdrSig))
     _writele(w._io, UInt16(_ZipVersion))
-    _writele(w._io, UInt16(0))
+    _writele(w._io, UInt16(_UnicodeFlag))
     _writele(w._io, UInt16(f.method))
     _writele(w._io, UInt16(f.dostime))
     _writele(w._io, UInt16(f.dosdate))


### PR DESCRIPTION
Fixes #84.

Each commit explains the purpose of the different changes so hopefully everything is clear enough.
The changes were mostly based on how Python's "zipfile" module handles UTF-8, which in my experience seems to work fine across different platforms.
I have tested the changes on both Linux and macOS and for both the original tests included pass and Unicode is handled correctly by the "native" zip tools (for Linux I tested with Python's zipfile, GNOME File Roller and INFO-Zip's unzip and for macOS I tested Python's zipfile, the native macOS graphical unarchiver and INFO-Zip's unzip). The major platform I haven't been able to test is Windows (due to lack of access to a Windows computer with Julia), which probably should be done before merging to make sure Unicode is handled fine there too.