### PR TITLE
docstring typo fix

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -148,7 +148,7 @@ mutable struct WritableFile <: IO
 end
 
 """
-Reader represents a ZIP file open for writing.
+Writer represents a ZIP file open for writing.
 
     Writer(io::IO)
     Writer(filename::AbstractString)


### PR DESCRIPTION
This seems to be a typo in the `Writer` docstring.