### PR TITLE
typo in an error message in ZipFile.jl

### DIFF
--- a/src/ZipFile.jl
+++ b/src/ZipFile.jl
@@ -286,7 +286,7 @@ function _find_sigoffset(io::IO, sig::UInt32)
         end
     end
     if offset === nothing
-        error("failed to find end of centeral directory record")
+        error("failed to find end of central directory record")
     end
     offset
 end


### PR DESCRIPTION
fixed a typo in the error message when the end of the central directory record could not be found