### PR TITLE
Allow compressing arrays larger than 4 GB

### DIFF
--- a/src/Zlib.jl
+++ b/src/Zlib.jl
@@ -122,9 +122,9 @@ end
 
 Writer(io::IO, raw::Bool=false) = Writer(io, 9, raw)
 
-function Base.unsafe_write(w::Writer, p::Ptr{UInt8}, nb::UInt)
+function Base.unsafe_write(w::Writer, p::Ptr{UInt8}, nb::UInt)::UInt
     if nb == 0
-        return zero(nb)
+        return UInt(0)
     end
     max_chunk_size::UInt = UInt(typemax(Cuint))>>1
     chunk_offset = UInt(0)
@@ -358,7 +358,7 @@ function unsafe_crc32(p::Ptr{UInt8}, nb::UInt, crc::UInt32)::UInt32
     while num_bytes_left > 0
         chunk_size = min(max_chunk_size, num_bytes_left)
         @assert chunk_offset + chunk_size ≤ nb
-        crc = ccall((:crc32, libz),
+        crc::UInt32 = ccall((:crc32, libz),
             Culong, (Culong, Ptr{UInt8}, Cuint),
             crc, p + chunk_offset, chunk_size,
         )

--- a/src/Zlib.jl
+++ b/src/Zlib.jl
@@ -351,7 +351,7 @@ function eof(r::Reader)
     bytesavailable(r.buf) == 0 && eof(r.io)
 end
 
-function unsafe_crc32(p::Ptr{UInt8}, nb::UInt, crc::UInt32)
+function unsafe_crc32(p::Ptr{UInt8}, nb::UInt, crc::UInt32)::UInt32
     max_chunk_size::UInt = UInt(typemax(Cuint))>>1
     chunk_offset = UInt(0)
     num_bytes_left = nb
@@ -370,7 +370,7 @@ end
 
 function crc32(data::AbstractArray{UInt8}, crc::Integer=0)::UInt32
     GC.@preserve data begin
-        unsafe_crc32(pointer(data), UInt(length(data)), crc)
+        unsafe_crc32(pointer(data), UInt(length(data)), UInt32(crc))
     end
 end
 

--- a/src/Zlib.jl
+++ b/src/Zlib.jl
@@ -352,20 +352,10 @@ function eof(r::Reader)
 end
 
 function unsafe_crc32(p::Ptr{UInt8}, nb::UInt, crc::UInt32)::UInt32
-    max_chunk_size::UInt = UInt(typemax(Cuint))>>1
-    chunk_offset = UInt(0)
-    num_bytes_left = nb
-    while num_bytes_left > 0
-        chunk_size = min(max_chunk_size, num_bytes_left)
-        @assert chunk_offset + chunk_size ≤ nb
-        crc::UInt32 = ccall((:crc32, libz),
-            Culong, (Culong, Ptr{UInt8}, Cuint),
-            crc, p + chunk_offset, chunk_size,
-        )
-        chunk_offset += chunk_size
-        num_bytes_left -= chunk_size
-    end
-    crc
+    ccall((:crc32_z, libz),
+        Culong, (Culong, Ptr{UInt8}, Csize_t),
+        crc, p, nb,
+    )
 end
 
 function crc32(data::AbstractArray{UInt8}, crc::Integer=0)::UInt32

--- a/test/bigtests.jl
+++ b/test/bigtests.jl
@@ -1,0 +1,43 @@
+# These tests require over 8 GB of memory and a 64 bit Int
+
+using ZipFile
+using Test
+
+@testset "big array with Zlib" begin
+    big_array = collect(1:2^29+2^25)
+    
+    io = IOBuffer()
+    w = ZipFile.Zlib.Writer(io, 1, true)
+    write(w, big_array)
+    close(w)
+    w = nothing
+    @info "done writing big_array"
+    seekstart(io)
+    r = ZipFile.Zlib.Reader(io, true)
+    buffer = zeros(Int, 2^22)
+    for bi in 1:(length(big_array)>>22)
+        read!(r, buffer)
+        @test ((bi-1)<<22+1):(bi<<22) == buffer
+    end
+    close(r)
+    r = nothing
+    close(io)
+    io = nothing
+    @info "done reading big_array"
+
+    # Check that crc32 works
+    crc32_big::UInt32 = ZipFile.Zlib.crc32(
+        reinterpret(UInt8, big_array)
+    )
+    crc32_parts::UInt32 = 0
+    for bi in 1:(length(big_array)>>22)
+        crc32_parts = ZipFile.Zlib.crc32(
+            reinterpret(UInt8, view(big_array,((bi-1)<<22+1):(bi<<22))),
+            crc32_parts
+        )
+    end
+    @test crc32_parts == crc32_big
+
+    
+    big_array = nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,4 +182,8 @@ if !Debug
     rm(tmp, recursive=true)
 end
 
+if "bigtests" in ARGS
+    include("bigtests.jl")
+end
+
 println("done")


### PR DESCRIPTION
Work toward fixing #95

Before this PR `Zlib.Writer` and `Zlib.crc32` could not handle more than 4 GB at a time because of a limitation of the zlib C library.

This PR runs the compressor on chunks of the input data in a loop to avoid the issue.

To test this requires at least 8 GB of memory, so I put the tests in a separate file, `"bigtests.jl"`.

To run these tests run:

```julia
julia> import Pkg

julia> Pkg.test("ZipFile"; test_args=["bigtests"])
```

Or just run `"bigtests.jl"` as a julia script in a project with ZipFile.


